### PR TITLE
As well as set_time_limit

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,6 +15,7 @@ If not, see <http://www.gnu.org/licenses/>.
 ini_set('log_errors', 1);
 ini_set('error_log', '/tmp/php-error-index.log');
 set_time_limit(0);
+ignore_user_abort(1);
 require_once 'src/PWRTelegram/PWRTelegram/Tools.php';
 require_once 'src/PWRTelegram/PWRTelegram/API.php';
 require_once 'src/PWRTelegram/PWRTelegram/Proxy.php';


### PR DESCRIPTION
Also use ignore_user_abort() to bypass browser abort. The script will keep running even if you close the browser (use with caution).
