### PR TITLE
Update Main.php

### DIFF
--- a/src/PWRTelegram/PWRTelegram/Main.php
+++ b/src/PWRTelegram/PWRTelegram/Main.php
@@ -367,7 +367,7 @@ class Main extends Proxy
 
                 default:
                 foreach ($this->REQUEST as &$param) {
-                    $json = json_decode($param, true);
+                    $json = json_decode(json_encode($param), true); // solution of this error: json_decode() expects parameter 1 to be string...
                     if (is_array($json)) {
                         $param = $json;
                     }


### PR DESCRIPTION
solution of this error: json_decode() expects parameter 1 to be string...
sample:
http://api.pwrtelegram.xyz/user<TOKEN>/messages.forwardMessages?from_peer=@wecangp&to_peer=@WeCanCo&id[]=57